### PR TITLE
Set hibernate search configuration via java properties

### DIFF
--- a/core/src/main/java/pt/ist/fenixframework/util/FileLookup.java
+++ b/core/src/main/java/pt/ist/fenixframework/util/FileLookup.java
@@ -1,0 +1,43 @@
+package pt.ist.fenixframework.util;
+
+import java.net.URL;
+
+/**
+ * Looks in the current class path for a particular file
+ *
+ * @author Pedro Ruivo
+ * @since 2.0
+ */
+public class FileLookup {
+
+   /**
+    * Looks in the class path for a file. The file name is returned by the property {@param propertyName} value and
+    * if this value is not found, it uses the {@param defaultFileName}
+    *
+    * @param propertyName     the property name that contains the file name to find
+    * @param defaultFileName  the default file name (if the properties is not found)
+    * @return                 the URL for the file defined by {@param fileName}
+    */
+   public static URL find(String propertyName, String defaultFileName) {
+      String fileName;
+      if (propertyName != null) {
+         fileName = System.getProperty(propertyName, defaultFileName);
+      } else {
+         fileName = defaultFileName;
+      }
+      return find(fileName);
+   }
+
+   /**
+    * @param fileName   the file name
+    * @return           the URL for the file defined by {@param fileName}
+    */
+   public static URL find(String fileName) {
+      URL url = Thread.currentThread().getContextClassLoader().getResource(fileName);
+      if (url == null) {
+         url = ClassLoader.getSystemClassLoader().getResource(fileName);
+      }
+      return url;
+   }
+
+}

--- a/hibernate-search/src/main/java/pt/ist/fenixframework/hibernatesearch/HibernateSearchConfig.java
+++ b/hibernate-search/src/main/java/pt/ist/fenixframework/hibernatesearch/HibernateSearchConfig.java
@@ -1,20 +1,19 @@
 package pt.ist.fenixframework.hibernatesearch;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.Properties;
-
-import javax.transaction.RollbackException;
-import javax.transaction.SystemException;
-import javax.transaction.Transaction;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import pt.ist.fenixframework.FenixFramework;
 import pt.ist.fenixframework.TransactionListener;
 import pt.ist.fenixframework.dap.FFDAPConfig;
 import pt.ist.fenixframework.txintrospector.TxStats;
+import pt.ist.fenixframework.util.FileLookup;
+
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Properties;
 
 public abstract class HibernateSearchConfig extends FFDAPConfig {
 
@@ -24,15 +23,16 @@ public abstract class HibernateSearchConfig extends FFDAPConfig {
      * This well-known name specifies the location of the properties file used to configure
      * Hibernate Search.  This file should be available in the application's classpath.
      */
-    public static final String CONFIG_FILE = "fenix-framework-hibernate-search.properties";
+    private static final String DEFAULT_CONFIG_FILE = "fenix-framework-hibernate-search.properties";
+    private static final String CONFIG_FILE_PROPERTY = "fenix-framework-hibernate-search-config-file";
 
     @Override
     protected void init() {
         super.init();
 
-        URL hibernateSearchConfigURL = Thread.currentThread().getContextClassLoader().getResource(CONFIG_FILE);
+        URL hibernateSearchConfigURL = FileLookup.find(CONFIG_FILE_PROPERTY, DEFAULT_CONFIG_FILE);
         if (hibernateSearchConfigURL == null) {
-            logger.info("Resource '" + CONFIG_FILE + "' not found. Hibernate Search disabled");
+            logger.info("Resource '" + DEFAULT_CONFIG_FILE + "' not found. Hibernate Search disabled");
             return;
         }
         logger.info("Using config resource: " + hibernateSearchConfigURL);
@@ -47,8 +47,8 @@ public abstract class HibernateSearchConfig extends FFDAPConfig {
         // Ensure TxIntrospector is available
         if (! TxStats.ENABLED) {
             logger.error("TxIntrospector is disabled!" +
-                         " -> Module Hibernate-search will not be available." +
-                         " Please enable TxIntrospector and rebuild your application");
+                    " -> Module Hibernate-search will not be available." +
+                    " Please enable TxIntrospector and rebuild your application");
             return;
         }
 


### PR DESCRIPTION
Hi Sérgio,

this commit allows you to set the Hibernate Search config file name via property using:

-Dfenix-framework-hibernate-search-config-file=<filename>

If you want, you can extend this method to the other FF's config file names.

Pedro
