### PR TITLE
Remove a missing dependency in MANIFEST.MF of hibernate-search

### DIFF
--- a/hibernate-search/pom.xml
+++ b/hibernate-search/pom.xml
@@ -36,12 +36,13 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${version.maven.jar-plugin}</version>
                 <configuration>
-                    <archive>
-                        <manifestEntries>
+                    <!-- In the future, when JBoss AS contains a hibernate-search module, we'll uncomment this -->
+                    <!-- <archive> -->
+                    <!--     <manifestEntries> -->
                             <!-- This specifies to the JBoss AS, the runtime dependencies of the jar being created -->
-                            <Dependencies>org.hibernate.search.engine:main</Dependencies>
-                        </manifestEntries>
-                    </archive>
+                    <!--         <Dependencies>org.hibernate.search.engine:main</Dependencies> -->
+                    <!--     </manifestEntries> -->
+                    <!-- </archive> -->
                     <excludes>
                         <exclude>**/*_Base*</exclude>
                         <exclude>pt/ist/fenixframework/ValueTypeSerializer*</exclude>


### PR DESCRIPTION
- This is really a required dependency.  However, the
  `org.hibernate.search.engine:main` does not exist yet in JBoss AS7 that
  ships with TorqueBox-2.3.0.  And, mentioning inexistent dependencies
  causes the deployment to fail. So, when such module becomes available
  we'll restore the dependency statement.
