### PR TITLE
New constructor and possible to add hints after creation

### DIFF
--- a/cloudtm-locality-hints/src/main/java/eu/cloudtm/LocalityHints.java
+++ b/cloudtm-locality-hints/src/main/java/eu/cloudtm/LocalityHints.java
@@ -21,7 +21,10 @@ public class LocalityHints {
     private static volatile KeyFeatureManager cloudtmFeatureManager;
     private final Map<String, String> keyValues;
 
-    public LocalityHints(String... hints) {
+    public LocalityHints(String[] hints) {
+        if (hints == null) {
+            throw new NullPointerException("Hints array cannot be null.");
+        }
         this.keyValues = new HashMap<String, String>(hints.length / 2);
         for (int i = 0; i < hints.length; ++i) {
             if (i + 1 >= hints.length) {
@@ -29,6 +32,10 @@ public class LocalityHints {
             }
             keyValues.put(hints[i++], hints[i]);
         }
+    }
+
+    public LocalityHints() {
+        this.keyValues = new HashMap<String, String>();
     }
 
     private LocalityHints(Map<String, String> keyValues) {
@@ -60,6 +67,10 @@ public class LocalityHints {
             throw new IllegalArgumentException("String " + hints + " is not a valid string");
         }
         return new LocalityHints(keyValues);
+    }
+
+    public final synchronized void addHint(String key, String value) {
+        this.keyValues.put(key, value);
     }
 
     private static void checkIfInitialized() {

--- a/cloudtm-locality-hints/src/test/java/eu/cloudtm/LocalityHintsTest.java
+++ b/cloudtm-locality-hints/src/test/java/eu/cloudtm/LocalityHintsTest.java
@@ -13,12 +13,12 @@ public class LocalityHintsTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testWrongParameters() {
-        new LocalityHints("bla");
+        new LocalityHints(new String[] {"bla"});
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
     public void testIfInitialized() {
-        LocalityHints hints = new LocalityHints(Constants.GROUP_ID, "bla");
+        LocalityHints hints = new LocalityHints(new String[] {Constants.GROUP_ID, "bla"});
         hints.hints2String();
     }
 

--- a/core/src/test/java/eu/cloudtm/LocalityHintsTest.java
+++ b/core/src/test/java/eu/cloudtm/LocalityHintsTest.java
@@ -24,7 +24,7 @@ public class LocalityHintsTest {
     public void testFeatureEquality() {
         LocalityHints.init(TEST_MANAGER);
 
-        LocalityHints hints = new LocalityHints("feature1", "value1", "feature2", "value2", "feature3", "value3");
+        LocalityHints hints = new LocalityHints(new String[] {"feature1", "value1", "feature2", "value2", "feature3", "value3"});
 
         Assert.assertEquals(hints.get("feature1"), "value1", "Error checking feature1.");
         Assert.assertEquals(hints.get("feature2"), "value2", "Error checking feature2.");
@@ -44,7 +44,7 @@ public class LocalityHintsTest {
     public void testFeatureAndGroupEquality() {
         LocalityHints.init(TEST_MANAGER);
 
-        LocalityHints hints = new LocalityHints("feature1", "value1", "feature2", "value2", Constants.GROUP_ID, "group");
+        LocalityHints hints = new LocalityHints(new String[] {"feature1", "value1", "feature2", "value2", Constants.GROUP_ID, "group"});
 
         Assert.assertEquals(hints.get("feature1"), "value1", "Error checking feature1.");
         Assert.assertEquals(hints.get("feature2"), "value2", "Error checking feature2.");

--- a/test/test-locality-hints/src/test/java/eu/cloudtm/CloudtmFeatureManagerTest.java
+++ b/test/test-locality-hints/src/test/java/eu/cloudtm/CloudtmFeatureManagerTest.java
@@ -40,7 +40,7 @@ public class CloudtmFeatureManagerTest {
 
     @Test
     public void testSimpleHints() {
-        LocalityHints hints = new LocalityHints(Constants.GROUP_ID, "group", "feature1", "1", "feature2", "2");
+        LocalityHints hints = new LocalityHints(new String[] {Constants.GROUP_ID, "group", "feature1", "1", "feature2", "2"});
         createTestPerson(hints);
 
         CloudtmFeatureManager manager = TEST_MANAGER;
@@ -62,7 +62,7 @@ public class CloudtmFeatureManagerTest {
 
     @Test
     public void testOnlyGroup() {
-        LocalityHints hints = new LocalityHints(Constants.GROUP_ID, "group");
+        LocalityHints hints = new LocalityHints(new String[]{Constants.GROUP_ID, "group"});
         createTestPerson(hints);
 
         CloudtmFeatureManager manager = TEST_MANAGER;


### PR DESCRIPTION
As requested by Fabio (from Algorithmica):

"Maybe you can provide 2 new constructors: 
1) without arguments (in this case I need an extra method to add the key/value pairs),
2) with argument String[]"

It looks like JRuby does not like LocalityHints(String... hints)
