### PR TITLE
Avoid generating an extra space in SerializedFormConstructor

### DIFF
--- a/backend-jvstm-ojb/src/main/java/pt/ist/fenixframework/backend/jvstmojb/codeGenerator/FenixCodeGeneratorOneBoxPerObject.java
+++ b/backend-jvstm-ojb/src/main/java/pt/ist/fenixframework/backend/jvstmojb/codeGenerator/FenixCodeGeneratorOneBoxPerObject.java
@@ -240,7 +240,7 @@ public class FenixCodeGeneratorOneBoxPerObject extends FenixCodeGenerator {
 
     protected void generateSerializedFormConstructor(DomainClass domClass, PrintWriter out) {
         newline(out);
-        printMethod(out, "protected", "", "SerializedForm", makeArg("DO_State", "obj"));
+        printConstructor(out, "protected", "SerializedForm", makeArg("DO_State", "obj"));
         startMethodBody(out);
         print(out, "super(obj);");
 


### PR DESCRIPTION
Changed printMethod to printConstructor. Avoids generating an extra space.
