### PR TITLE
[core/api]  Re-enable programmatic config with auto appName discovery

### DIFF
--- a/core/api/src/main/java/pt/ist/fenixframework/MultiConfig.java
+++ b/core/api/src/main/java/pt/ist/fenixframework/MultiConfig.java
@@ -39,10 +39,16 @@ public class MultiConfig {
      * @return the previous configuration for the same backend, or null if there was none
      */
     public Config add(Config config) {
-        return configs.put(config.getBackEndName(), config);
+        String backEndName = config.getBackEndName();
+
+        logger.info("Registering config for backend {}", backEndName);
+
+        return configs.put(backEndName, config);
     }
 
     public Config get(String backEndName) {
+        logger.info("Looking up config for backend {}", backEndName);
+
         Config config = configs.get(backEndName);
         if (config == null) {
             logger.warn(UNKNOWN_BACKEND + backEndName);


### PR DESCRIPTION
- After commit 58e7c2740da731caa8a8f13da90c13ee3835b52a, appName discovery
  became automatic when such property was not provided in a configuration
  file.  However, that feature also disabled the ability to detect explicit
  (programmatic) configuration.  This commit reenables it.
- Automatic discovery of the appName value occurs if any of the following is
  true:
  - there is at least (any) one property set (either via
    fenix-framework.properties, fenix-framework-<backendName>.properties
    or -Dfenixframweork.PROPERTY=)
  - the property appName is set and its value is either "" (empty string)
    or "INFER_APP_NAME"
- As a corollary, backends that do not require extra configuration
  properties (other than appName) and still would like to use the appName
  auto-discovery feature, MUST set appName to either "" or "INFER_APP_NAME".
