### PR TITLE
[consistency-predicates] Model relation with AbstractDomainObject instead of DomainObject

### DIFF
--- a/core/consistency-predicates/src/main/dml/fenix-framework-consistency-predicates.dml
+++ b/core/consistency-predicates/src/main/dml/fenix-framework-consistency-predicates.dml
@@ -111,6 +111,6 @@ relation DependedDomainMetaObjectsDependingDependenceRecords {
 }
 
 relation DomainMetaObjectAbstractDomainObject {
-    .pt.ist.fenixframework.DomainObject playsRole domainObject;
+    .pt.ist.fenixframework.core.AbstractDomainObject playsRole domainObject;
 	DomainMetaObject playsRole;
 }

--- a/core/consistency-predicates/src/main/java/pt/ist/fenixframework/DomainMetaClass.java
+++ b/core/consistency-predicates/src/main/java/pt/ist/fenixframework/DomainMetaClass.java
@@ -236,7 +236,7 @@ public class DomainMetaClass extends DomainMetaClass_Base {
                 break;
             }
             for (String id : ids) {
-                DomainObject existingDO = null;
+                AbstractDomainObject existingDO = null;
                 try {
                     existingDO = FenixFramework.getDomainObject(id);
                 } catch (Exception ex) {

--- a/core/consistency-predicates/src/main/java/pt/ist/fenixframework/DomainMetaObject.java
+++ b/core/consistency-predicates/src/main/java/pt/ist/fenixframework/DomainMetaObject.java
@@ -6,6 +6,7 @@ import jvstm.cps.Depended;
 import pt.ist.fenixframework.consistencyPredicates.ConsistencyPredicateSupport;
 import pt.ist.fenixframework.consistencyPredicates.DomainConsistencyPredicate;
 import pt.ist.fenixframework.consistencyPredicates.DomainDependenceRecord;
+import pt.ist.fenixframework.core.AbstractDomainObject;
 
 /**
  * Each domain object is associated with one <code>DomainMetaObject</code>,
@@ -67,7 +68,7 @@ public class DomainMetaObject extends DomainMetaObject_Base implements Depended<
     }
 
     @Override
-    public void setDomainObject(DomainObject domainObject) {
+    public void setDomainObject(AbstractDomainObject domainObject) {
         if (domainObject == null) {
             DomainObject previousObject = getDomainObject();
             // These two sets are needed because the relation between a domainObject


### PR DESCRIPTION
- The DomainObject is an interface. The AbstractDomainObject is guaranteed to
  be the class from which all DomainObject implementations extend (whether
  directly or indirectly).  For now, in the DML, the relations modeled with
  "every domain class" should be related to AbstractDomainObject instead of
  DomainObject.
