### PR TITLE
Fix: initInstance hierarchy

### DIFF
--- a/backend/jvstm-common/code-generator/src/main/java/pt/ist/fenixframework/backend/jvstm/JVSTMCodeGenerator.java
+++ b/backend/jvstm-common/code-generator/src/main/java/pt/ist/fenixframework/backend/jvstm/JVSTMCodeGenerator.java
@@ -10,7 +10,6 @@ package pt.ist.fenixframework.backend.jvstm;
 import java.io.PrintWriter;
 
 import pt.ist.fenixframework.dml.CompilerArgs;
-import pt.ist.fenixframework.dml.DomainClass;
 import pt.ist.fenixframework.dml.DomainModel;
 import pt.ist.fenixframework.dml.IndexesCodeGenerator;
 import pt.ist.fenixframework.dml.Role;
@@ -116,16 +115,7 @@ public class JVSTMCodeGenerator extends IndexesCodeGenerator {
         println(out, ";");
     }
 
-    /* smf: adds generateInitSlot to what the CodeGenerator already does.  Perhaps we should move this to the upper method... */
     @Override
-    protected void generateInitInstanceMethodBody(DomainClass domClass, PrintWriter out) {
-        for (Slot slot : domClass.getSlotsList()) {
-            generateInitSlot(slot, out);
-        }
-        super.generateInitInstanceMethodBody(domClass, out);
-    }
-
-    /* smf: It might make sense to define this method in the CodeGenerator class */
     protected void generateInitSlot(Slot slot, PrintWriter out) {
         onNewline(out);
         printWords(out, slot.getName());

--- a/core/dml-compiler/code-generator/src/main/java/pt/ist/fenixframework/core/PostProcessDomainClasses.java
+++ b/core/dml-compiler/code-generator/src/main/java/pt/ist/fenixframework/core/PostProcessDomainClasses.java
@@ -127,12 +127,13 @@ public class PostProcessDomainClasses extends AbstractDomainPostProcessor {
                 mv.visitVarInsn(ALOAD, 1);
                 mv.visitMethodInsn(INVOKESPECIAL, superDesc, "<init>", CONSTRUCTOR_DESC);
 
-                if (isDomainBaseClass(descToName(classDesc))) {
-                    // for base classes, we must invoke the initInstance()
-                    // method
-                    mv.visitVarInsn(ALOAD, 0);
-                    mv.visitMethodInsn(INVOKESPECIAL, classDesc, "initInstance", "()V");
-                }
+//   Now, this invocation is performed by the AbstractDomainObject and the initInstance(s) is(are) protected (instead of provate)                
+//                if (isDomainBaseClass(descToName(classDesc))) {
+//                    // for base classes, we must invoke the initInstance()
+//                    // method
+//                    mv.visitVarInsn(ALOAD, 0);
+//                    mv.visitMethodInsn(INVOKESPECIAL, classDesc, "initInstance", "()V");
+//                }
 
                 mv.visitInsn(RETURN);
                 mv.visitMaxs(2, 2);

--- a/core/dml-compiler/code-generator/src/main/java/pt/ist/fenixframework/dml/CodeGenerator.java
+++ b/core/dml-compiler/code-generator/src/main/java/pt/ist/fenixframework/dml/CodeGenerator.java
@@ -674,7 +674,7 @@ public abstract class CodeGenerator {
     }
 
     /**
-     * The purpose of the initInstance method is to have the code needed to correctly initialize a
+     * The purpose of the init$Instance method is to have the code needed to correctly initialize a
      * domain object instance. There are two cases:
      * 
      * <ol>
@@ -685,19 +685,12 @@ public abstract class CodeGenerator {
      * <p>
      * In the first case the parameter 'allocateOnly' is false. Typically, we need to fully initialize the slots, e.g. create new
      * lists, etc. In the second case, the instance's attributes will be populated, so we should not create them anew.
-     * 
-     * <p>
-     * This method is responsible for: generating the <code>initInstance(boolean)</code> method; generate the call to this method
-     * as an instance initializer with the parameter <code>allocateInstance = false</code>.
      */
     protected void generateInitInstance(DomainClass domClass, PrintWriter out) {
         generateInitInstanceNoArg(domClass, out);
 
-        // generate initInstance method
+        // generate init$Instance method
         generateInitInstanceMethod(domClass, out);
-
-        // add instance initializer block that calls the initInstance method
-        generateInitInstanceInitializer(domClass, out);
     }
 
     protected void generateInitInstanceNoArg(DomainClass domClass, PrintWriter out) {
@@ -705,23 +698,24 @@ public abstract class CodeGenerator {
         newline(out);
         printMethod(out, "private", "void", "initInstance");
         startMethodBody(out);
-        print(out, "initInstance(true);");
+        print(out, "init$Instance(true);");
         endMethodBody(out);
     }
 
     protected void generateInitInstanceMethod(DomainClass domClass, PrintWriter out) {
-        onNewline(out);
         newline(out);
-        printMethod(out, "private", "void", "initInstance", makeArg("boolean", "allocateOnly"));
+        println(out, "@Override");
+        printMethod(out, "protected", "void", "init$Instance", makeArg("boolean", "allocateOnly"));
         startMethodBody(out);
         generateInitInstanceMethodBody(domClass, out);
         endMethodBody(out);
     }
 
     protected void generateInitInstanceMethodBody(DomainClass domClass, PrintWriter out) {
-        // for (Slot slot : domClass.getSlotsList()) {
-        //     generateInitSlot(slot, out);
-        // }
+        println(out, "super.init$Instance(allocateOnly);");
+        for (Slot slot : domClass.getSlotsList()) {
+            generateInitSlot(slot, out);
+        }
         onNewline(out);
 
         for (Role role : domClass.getRoleSlotsList()) {
@@ -731,11 +725,8 @@ public abstract class CodeGenerator {
         }
     }
 
-    protected void generateInitInstanceInitializer(DomainClass domClass, PrintWriter out) {
-        newline(out);
-        newBlock(out);
-        print(out, "initInstance(false);");
-        closeBlock(out);
+    protected void generateInitSlot(Slot slot, PrintWriter out) {
+        // do nothing by default
     }
 
     protected void generateInitRoleSlot(Role role, PrintWriter out) {

--- a/core/dml-compiler/dml/src/main/java/pt/ist/fenixframework/core/AbstractDomainObject.java
+++ b/core/dml-compiler/dml/src/main/java/pt/ist/fenixframework/core/AbstractDomainObject.java
@@ -48,6 +48,7 @@ public abstract class AbstractDomainObject implements DomainObject {
      */
     protected AbstractDomainObject() {
         super();
+        init$Instance(false);
         ensureOid();
     }
 
@@ -62,6 +63,7 @@ public abstract class AbstractDomainObject implements DomainObject {
      * documentation.
      */
     protected AbstractDomainObject(DomainObjectAllocator.OID oid) {
+        init$Instance(true);
     }
 
     /**
@@ -72,6 +74,15 @@ public abstract class AbstractDomainObject implements DomainObject {
      */
     protected void ensureOid() {
         throw new UnsupportedOperationException("ensureOid not implemented at this level");
+    }
+
+    /**
+     * Initialize this instance as needed.
+     * 
+     * @param allocateOnly <code>false</code> if this is a new instance. <code>true</code> otherwise (in which case the instance
+     *            should only be allocated, not fully initialized).
+     */
+    protected void init$Instance(boolean allocateOnly) {
     }
 
     @Override


### PR DESCRIPTION
- This problem was detected after adding DomainBPlusTree.  Problem: there
  was a bug in the invocation of LeafNode.setEntries() from the constructor
  of LeadNode. When actually creating an instance of DomainLeafNode, it
  would invoke the override DomainLeafNode.setEntries(), which would attempt
  to access a yet uninitialized slot (domainEntries).  The solution is to
  change how initInstance happens by invoking it only once from the
  top-level AbstractDomainObject class, instead of invoking it once per
  class hierarchy level.

@jcarvalho could you please review this PR and check that it doesn't break anything in jvstm-ojb? I only did a small run using FenixCodeGeneratorOneBoxPerObject and apparently it's ok (due to #141 I couldn't test with FenixCodeGenerator), but given that this commit affects the initInstance protocol, I'd like you to confirm it with a more serious test before merging.  In particular, I've disabled some of the processing done by PostProcessDomainClasses.AddOJBConstructorClassAdapter ([original here](https://github.com/fenix-framework/fenix-framework/blob/develop/core/dml-compiler/code-generator/src/main/java/pt/ist/fenixframework/core/PostProcessDomainClasses.java#L131)): I think that adding an invocation to initInstance in the 'allocation-only' constructor should no longer occur, because it's now being done in AbstractDomainObject's constructor.   
