### PR TITLE
Implemented method to return the cluster information, if available.

### DIFF
--- a/backend-jvstm-mem/src/main/java/pt/ist/fenixframework/backend/jvstmmem/JVSTMMemBackEnd.java
+++ b/backend-jvstm-mem/src/main/java/pt/ist/fenixframework/backend/jvstmmem/JVSTMMemBackEnd.java
@@ -4,6 +4,8 @@ import pt.ist.fenixframework.DomainObject;
 import pt.ist.fenixframework.DomainRoot;
 import pt.ist.fenixframework.TransactionManager;
 import pt.ist.fenixframework.backend.BackEnd;
+import pt.ist.fenixframework.backend.BasicClusterInformation;
+import pt.ist.fenixframework.backend.ClusterInformation;
 import pt.ist.fenixframework.core.SharedIdentityMap;
 
 public class JVSTMMemBackEnd implements BackEnd {
@@ -63,6 +65,12 @@ public class JVSTMMemBackEnd implements BackEnd {
     @Override
     public String[] getStorageKeys(DomainObject domainObject) {
         throw new UnsupportedOperationException("It does not make sense to invoke this method in a storage-less BackEnd");
+    }
+
+    @Override
+    public ClusterInformation getClusterInformation() {
+        //if I'm not mistaken, JVSTM only works in non-cluster environment
+        return ClusterInformation.LOCAL_MODE;
     }
 
 }

--- a/backend-mem/src/main/java/pt/ist/fenixframework/backend/mem/MemBackEnd.java
+++ b/backend-mem/src/main/java/pt/ist/fenixframework/backend/mem/MemBackEnd.java
@@ -7,6 +7,8 @@ import pt.ist.fenixframework.DomainObject;
 import pt.ist.fenixframework.DomainRoot;
 import pt.ist.fenixframework.TransactionManager;
 import pt.ist.fenixframework.backend.BackEnd;
+import pt.ist.fenixframework.backend.BasicClusterInformation;
+import pt.ist.fenixframework.backend.ClusterInformation;
 import pt.ist.fenixframework.core.SharedIdentityMap;
 
 public class MemBackEnd implements BackEnd {
@@ -70,5 +72,11 @@ public class MemBackEnd implements BackEnd {
     @Override
     public String[] getStorageKeys(DomainObject domainObject) {
         throw new UnsupportedOperationException("It does not make sense to invoke this method in a storage-less BackEnd");
+    }
+
+    @Override
+    public ClusterInformation getClusterInformation() {
+        //local-only back end
+        return ClusterInformation.LOCAL_MODE;
     }
 }

--- a/backend-ogm/src/main/java/pt/ist/fenixframework/backend/ogm/OgmBackEnd.java
+++ b/backend-ogm/src/main/java/pt/ist/fenixframework/backend/ogm/OgmBackEnd.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import pt.ist.fenixframework.DomainObject;
 import pt.ist.fenixframework.DomainRoot;
 import pt.ist.fenixframework.backend.BackEnd;
+import pt.ist.fenixframework.backend.ClusterInformation;
 import pt.ist.fenixframework.core.AbstractDomainObject;
 
 public class OgmBackEnd implements BackEnd {
@@ -82,6 +83,11 @@ public class OgmBackEnd implements BackEnd {
     @Override
     public String[] getStorageKeys(DomainObject domainObject) {
         throw new UnsupportedOperationException("not yet implemented. Depends on support from the Hibernate OGM.");
+    }
+
+    @Override
+    public ClusterInformation getClusterInformation() {
+        return ClusterInformation.NOT_AVAILABLE;
     }
 
     // protected IdentityMap getIdentityMap() {

--- a/core/src/main/java/pt/ist/fenixframework/FenixFramework.java
+++ b/core/src/main/java/pt/ist/fenixframework/FenixFramework.java
@@ -10,6 +10,8 @@ import org.slf4j.LoggerFactory;
 
 import pt.ist.fenixframework.backend.BackEnd;
 import pt.ist.fenixframework.backend.BackEndId;
+import pt.ist.fenixframework.backend.BasicClusterInformation;
+import pt.ist.fenixframework.backend.ClusterInformation;
 import pt.ist.fenixframework.dml.DmlCompilerException;
 import pt.ist.fenixframework.dml.DomainModel;
 import pt.ist.fenixframework.util.NodeBarrier;
@@ -442,5 +444,14 @@ public class FenixFramework {
 
     public static void barrier(String barrierName, int expectedMembers) throws Exception {
         getNodeBarrier().blockUntil(barrierName, expectedMembers);
+    }
+
+    /**
+     * See {@link pt.ist.fenixframework.backend.BackEnd#getClusterInformation()} and {@link pt.ist.fenixframework.backend.ClusterInformation}.
+     *
+     * @return the current cluster information.
+     */
+    public static ClusterInformation getClusterInformation() {
+        return getConfig().getBackEnd().getClusterInformation();
     }
 }

--- a/core/src/main/java/pt/ist/fenixframework/backend/BackEnd.java
+++ b/core/src/main/java/pt/ist/fenixframework/backend/BackEnd.java
@@ -58,4 +58,16 @@ public interface BackEnd {
      */
     public String[] getStorageKeys(DomainObject domainObject);
 
+    /**
+     * Special values:
+     *
+     * <ul>
+     *     <li>{@link ClusterInformation#LOCAL_MODE}: if Fénix Framework is used in local-mode only</li>
+     *     <li>{@link ClusterInformation#NOT_AVAILABLE}: if no information is available</li>
+     * </ul>
+     *
+     * @return the cluster information in which this node belong to.
+     */
+    public ClusterInformation getClusterInformation();
+
 }

--- a/core/src/main/java/pt/ist/fenixframework/backend/BasicClusterInformation.java
+++ b/core/src/main/java/pt/ist/fenixframework/backend/BasicClusterInformation.java
@@ -1,0 +1,49 @@
+package pt.ist.fenixframework.backend;
+
+/**
+ * Default implementation of {@link ClusterInformation} with th basic the basic information, i.e., the number of nodes
+ * available and tis node index.
+ *
+ * @author Pedro Ruivo
+ * @since 2.5
+ */
+public class BasicClusterInformation implements ClusterInformation {
+
+    private final int numberOfNodes;
+    private final int nodeIndex;
+
+    public BasicClusterInformation(int numberOfNodes, int nodeIndex) {
+        this.numberOfNodes = numberOfNodes;
+        this.nodeIndex = nodeIndex;
+    }
+
+    @Override
+    public final int getNumberOfNodes() {
+        return numberOfNodes;
+    }
+
+    @Override
+    public final int getNodeIndex() {
+        return nodeIndex;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BasicClusterInformation that = (BasicClusterInformation) o;
+
+        if (nodeIndex != that.nodeIndex) return false;
+        if (numberOfNodes != that.numberOfNodes) return false;
+
+        return true;
+    }
+
+    @Override
+    public final int hashCode() {
+        int result = numberOfNodes;
+        result = 31 * result + nodeIndex;
+        return result;
+    }
+}

--- a/core/src/main/java/pt/ist/fenixframework/backend/ClusterInformation.java
+++ b/core/src/main/java/pt/ist/fenixframework/backend/ClusterInformation.java
@@ -1,0 +1,74 @@
+package pt.ist.fenixframework.backend;
+
+/**
+ * Contains the cluster information related to this node when Fenix Framework has used in a clustering environment.
+ *
+ * @author Pedro Ruivo
+ * @since 2.5
+ */
+public interface ClusterInformation {
+
+    /**
+     * Instance that represents a local-mode Fénix Framework usage.
+     */
+    public static final ClusterInformation LOCAL_MODE = new ClusterInformation() {
+
+        @Override
+        public final int getNumberOfNodes() {
+            return 1;
+        }
+
+        @Override
+        public final int getNodeIndex() {
+            return 0;
+        }
+
+        @Override
+        public final int hashCode() {
+            return 1;
+        }
+
+        @Override
+        public final boolean equals(Object obj) {
+            return this == obj;
+
+        }
+    };
+
+    /**
+     * Instance that represents the cases where if it not possible to know if we are in a clustered environment or
+     * local mode.
+     */
+    public static final ClusterInformation NOT_AVAILABLE = new ClusterInformation() {
+        @Override
+        public final int getNumberOfNodes() {
+            return -1;
+        }
+
+        @Override
+        public final int getNodeIndex() {
+            return -1;
+        }
+
+        @Override
+        public final int hashCode() {
+            return 2;
+        }
+
+        @Override
+        public final boolean equals(Object obj) {
+            return this == obj;
+        }
+    };
+
+    /**
+     * @return the number of nodes running Fenix Framework in the cluster.
+     */
+    public int getNumberOfNodes();
+
+    /**
+     * @return the node index in the cluster. The index is between 0 (inclusive) and {@link #getNumberOfNodes()} (exclusive)
+     */
+    public int getNodeIndex();
+
+}


### PR DESCRIPTION
As discussed in today's email:

we need to obtain from ISPN:
- the number of nodes in the current cluster
- the id of the current node in the Cache View
