### PR TITLE
Bugfix: add RemoteCommit.toString()

### DIFF
--- a/backend/jvstm-cluster/src/main/java/pt/ist/fenixframework/backend/jvstm/cluster/ClusterUtils.java
+++ b/backend/jvstm-cluster/src/main/java/pt/ist/fenixframework/backend/jvstm/cluster/ClusterUtils.java
@@ -204,23 +204,9 @@ public class ClusterUtils {
     }
 
     public static void sendCommitInfoToOthers(RemoteCommit remoteCommit) {
+        // test for debug, because computing remoteCommit.toString() is expensive
         if (logger.isDebugEnabled()) {
-            StringBuilder str = new StringBuilder();
-            str.append("serverId=").append(remoteCommit.getServerId());
-            str.append(", txNumber=").append(remoteCommit.getTxNumber());
-            str.append(", changes={");
-            int size = remoteCommit.getOids().length;
-            for (int i = 0; i < size; i++) {
-                if (i != 0) {
-                    str.append(", ");
-                }
-                long oid = remoteCommit.getOids()[i];
-                String slotName = remoteCommit.getSlotNames()[i];
-                str.append('(').append(Long.toHexString(oid)).append(':').append(slotName).append(')');
-            }
-            str.append("}");
-
-            logger.debug("Send commit info to others: {}", str.toString());
+            logger.debug("Send commit info to others: {}", remoteCommit);
         }
 
         ITopic<RemoteCommit> topic = getHazelcastInstance().getTopic(FF_COMMIT_TOPIC_NAME);

--- a/backend/jvstm-cluster/src/main/java/pt/ist/fenixframework/backend/jvstm/cluster/RemoteCommit.java
+++ b/backend/jvstm-cluster/src/main/java/pt/ist/fenixframework/backend/jvstm/cluster/RemoteCommit.java
@@ -109,6 +109,25 @@ public class RemoteCommit implements DataSerializable {
         }
     }
 
+    @Override
+    public String toString() {
+        StringBuilder str = new StringBuilder();
+        str.append("serverId=").append(getServerId());
+        str.append(", txNumber=").append(getTxNumber());
+        str.append(", changes={");
+        int size = getOids().length;
+        for (int i = 0; i < size; i++) {
+            if (i != 0) {
+                str.append(", ");
+            }
+            long oid = getOids()[i];
+            String slotName = getSlotNames()[i];
+            str.append('(').append(Long.toHexString(oid)).append(':').append(slotName).append(')');
+        }
+        str.append("}");
+        return str.toString();
+    }
+
     public static class SpeculativeRemoteCommit extends RemoteCommit {
         private static final long serialVersionUID = 1L;
 
@@ -176,6 +195,21 @@ public class RemoteCommit implements DataSerializable {
 
                 this.slotNames[i] = it.next().getAsString();
                 this.oids[i] = it.next().getAsLong();
+            }
+        }
+
+        @Override
+        public String toString() {
+            // if this is remote commit was received then the oids array is set.  Otherwise, we'll print the JSON array
+            if (getOids() != null) {
+                return super.toString();
+            } else {
+                StringBuilder str = new StringBuilder();
+                str.append("serverId=").append(getServerId());
+                str.append(", txNumber=").append(getTxNumber());
+                str.append(", changes=");
+                str.append(commitData);
+                return str.toString();
             }
         }
     }


### PR DESCRIPTION
This allows the logger in ClusterUtils.sendCommitInfoToOthers to be able to
abstract itself from what type of RemoteCommit we're using.  When the
SpeculativeRemoteCommit was added it had introduced a bug here.
