### PR TITLE
Support a clean shutdown for FenixFramework

### DIFF
--- a/backend/jvstm-common/runtime/src/main/java/pt/ist/fenixframework/backend/jvstm/JVSTMBackEnd.java
+++ b/backend/jvstm-common/runtime/src/main/java/pt/ist/fenixframework/backend/jvstm/JVSTMBackEnd.java
@@ -24,6 +24,7 @@ import pt.ist.fenixframework.backend.jvstm.pstm.FenixFrameworkData;
 import pt.ist.fenixframework.backend.jvstm.pstm.NonPersistentTopLevelReadOnlyTransaction;
 import pt.ist.fenixframework.backend.jvstm.pstm.NonPersistentTopLevelTransaction;
 import pt.ist.fenixframework.backend.jvstm.pstm.VBox;
+import pt.ist.fenixframework.backend.jvstm.pstm.VBoxCache;
 import pt.ist.fenixframework.backend.jvstm.repository.NoRepository;
 import pt.ist.fenixframework.backend.jvstm.repository.Repository;
 import pt.ist.fenixframework.core.AbstractDomainObject;
@@ -214,6 +215,7 @@ public class JVSTMBackEnd implements BackEnd {
 
     @Override
     public void shutdown() {
+        VBoxCache.getCache().shutdown();
     }
 
     public Repository getRepository() {

--- a/backend/jvstm-common/runtime/src/main/java/pt/ist/fenixframework/backend/jvstm/pstm/VBoxCache.java
+++ b/backend/jvstm-common/runtime/src/main/java/pt/ist/fenixframework/backend/jvstm/pstm/VBoxCache.java
@@ -68,6 +68,13 @@ public class VBoxCache {
         this.cache.remove(entry.key, entry);
     }
 
+    /**
+     * This method is invoked when shutting down. It clears the cache contents.
+     */
+    public void shutdown() {
+        this.cache.clear();
+    }
+
     /* This method stores the new value if an older one didn't exist already.  In either case it returns the value that was left
      * in the cache.  This implementation works as intended because we assume that we never store a null value in the
      * cache. Otherwise, map.putIfAbsent would not put a new value over a null entry.

--- a/core/api/src/main/java/pt/ist/fenixframework/FenixFramework.java
+++ b/core/api/src/main/java/pt/ist/fenixframework/FenixFramework.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import pt.ist.fenixframework.backend.BackEndId;
 import pt.ist.fenixframework.core.Project;
+import pt.ist.fenixframework.core.SharedIdentityMap;
 import pt.ist.fenixframework.dml.DomainModel;
 import pt.ist.fenixframework.util.NodeBarrier;
 
@@ -417,10 +418,14 @@ public class FenixFramework {
      */
     public static synchronized void shutdown() {
         logger.info("Shutting down...");
-        if (barrier != null) {
-            barrier.shutdown();
+        synchronized (INIT_LOCK) {
+            initialized = false;
+            if (barrier != null) {
+                barrier.shutdown();
+            }
+            getConfig().shutdown();
+            SharedIdentityMap.getCache().shutdown();
         }
-        getConfig().shutdown();
         logger.info("Shutdown complete.");
     }
 

--- a/core/api/src/main/java/pt/ist/fenixframework/core/SharedIdentityMap.java
+++ b/core/api/src/main/java/pt/ist/fenixframework/core/SharedIdentityMap.java
@@ -81,6 +81,13 @@ public class SharedIdentityMap implements IdentityMap {
         this.cache.remove(entry.key, entry);
     }
 
+    /**
+     * This method is invoked when shutting down. It clears the cache contents.
+     */
+    public void shutdown() {
+        this.cache.clear();
+    }
+
     /* This method stores the new value if an older one didn't exist already.  In either case it returns the value that was left
      * in the cache.  This implementation works as intended because we assume that we never store a null value in the
      * cache. Otherwise, map.putIfAbsent would not put a new value over a null entry.


### PR DESCRIPTION
This feature updates the FenixFramework.shutdown() showdown hook with the
  minimal funcionality to support a clean shutdown and later allow for a new
  call to FenixFramework.initialize(Config).  For now, it sets 'initialized'
  to false, and additionally clears the cache(s).  The shutdown now also uses
  the INIT_LOCK to operate.

  This feature hasn't been thoroughly tested.  Nevertheless, it is fully
  functional in the RadarGun benchmark.
