### PR TITLE
[jvstm-ojb] Remove key functions from base classes

### DIFF
--- a/backend/jvstm-ojb/code-generator/src/main/java/pt/ist/fenixframework/backend/jvstmojb/codeGenerator/FenixCodeGenerator.java
+++ b/backend/jvstm-ojb/code-generator/src/main/java/pt/ist/fenixframework/backend/jvstmojb/codeGenerator/FenixCodeGenerator.java
@@ -682,4 +682,9 @@ public abstract class FenixCodeGenerator extends CodeGenerator {
         return JvstmOJBConfig.class.getName();
     }
 
+    @Override
+    protected void generateStaticKeyFunctionForRole(Role role, PrintWriter out) {
+        // Nothing to do, this backend does not use Key Functions
+    }
+
 }


### PR DESCRIPTION
By overriding the `DefaultCodeGenerator`, base classes generated by the JVSTM/OJB Generator are generating Key Functions.

Those are used by the default implementation of domain relations, which are not used in this backend (in favor of RelationLists), thus rendering these functions useless.

By removing the functions, we should see an improvement in both startup time (less fields that have to be initialized) and a smaller memory footprint (not only by reducing the number of object instances, but also the number of loaded classes).