### PR TITLE
Skip pom dependencies. resolves #212

### DIFF
--- a/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/DmlMojoUtils.java
+++ b/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/DmlMojoUtils.java
@@ -35,7 +35,7 @@ public class DmlMojoUtils {
 
             if (artifact.getFile().isDirectory()) {
                 hasProjectProperties = new File(absolutePath + "/" + artifact.getArtifactId() + "/project.properties").exists();
-            } else {
+            } else if (!"pom".equals(artifact.getType())) {
                 JarFile jarFile = new JarFile(absolutePath);
                 hasProjectProperties = jarFile.getJarEntry(artifact.getArtifactId() + "/project.properties") != null;
                 jarFile.close();


### PR DESCRIPTION
Not sure if this is the best solution, but at least it will allow for the compile process to complete ignoring POM type dependencies.
