### PR TITLE
Support standard test location

### DIFF
--- a/backend/jvstm-inmem/code-generator/pom.xml
+++ b/backend/jvstm-inmem/code-generator/pom.xml
@@ -1,0 +1,71 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>pt.ist</groupId>
+        <artifactId>fenix-framework-backend-jvstm-inmem</artifactId>
+        <version>2.7.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>fenix-framework-backend-jvstm-inmem-code-generator</artifactId>
+    <name>Fenix Framework inmemory JVSTM common Code Generator</name>
+    <description>Inmemory only JVSTM-based backend</description>
+
+    <build>
+        <plugins>
+
+            <!-- Process dml file class immediately before compiling -->
+            <plugin>
+                <groupId>pt.ist</groupId>
+                <artifactId>ff-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>ff-generate-domain</goal>
+                            <goal>ff-process-atomic-annotations</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- setup jar maker not to include generated classes -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${version.maven.jar-plugin}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*_Base*</exclude>
+                        <exclude>pt/ist/fenixframework/ValueTypeSerializer*</exclude>
+                        <exclude>pt/ist/fenixframework/backend/CurrentBackEndId*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+        <groupId>pt.ist</groupId>
+        <artifactId>fenix-framework-core-dml-code-generator</artifactId>
+        <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>pt.ist</groupId>
+            <artifactId>fenix-framework-backend-jvstm-common-code-generator</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>pt.ist</groupId>
+            <artifactId>fenix-framework-backend-jvstm-inmem-runtime</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>pt.ist</groupId>
+            <artifactId>fenix-framework-core-indexes-code-generator</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/backend/jvstm-inmem/code-generator/src/main/java/pt/ist/fenixframework/backend/jvstm/InMemCodeGenerator.java
+++ b/backend/jvstm-inmem/code-generator/src/main/java/pt/ist/fenixframework/backend/jvstm/InMemCodeGenerator.java
@@ -1,0 +1,26 @@
+/*
+ * Fenix Framework, a framework to develop Java Enterprise Applications.
+ *
+ * Copyright (C) 2013 Fenix Framework Team and/or its affiliates and other contributors as indicated by the @author tags.
+ *
+ * This file is part of the Fenix Framework.  Read the file COPYRIGHT.TXT for more copyright and licensing information.
+ */
+package pt.ist.fenixframework.backend.jvstm;
+
+import pt.ist.fenixframework.dml.CompilerArgs;
+import pt.ist.fenixframework.dml.DomainModel;
+
+public class InMemCodeGenerator extends JVSTMCodeGenerator {
+    
+    public InMemCodeGenerator(CompilerArgs compArgs, DomainModel domainModel) {
+        super(compArgs, domainModel);
+    }
+    
+    
+    @Override
+    protected String getDomainClassRoot() {
+        return InMemDomainObject.class.getName();
+    }
+
+    
+}

--- a/backend/jvstm-inmem/pom.xml
+++ b/backend/jvstm-inmem/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<modelVersion>4.0.0</modelVersion>
+
+<parent>
+    <groupId>pt.ist</groupId>
+    <artifactId>fenix-framework-backend</artifactId>
+    <!-- Perhaps in Maven 3.1 the version may be ommitted -->
+    <version>2.7.0-SNAPSHOT</version>
+</parent>
+
+<artifactId>fenix-framework-backend-jvstm-inmem</artifactId>
+<name>Fenix Framework InMemory Backend</name>
+<packaging>pom</packaging>
+<url>http://fenix-ashes.ist.utl.pt</url>
+
+<modules>
+    <module>code-generator</module>
+    <module>runtime</module>
+</modules>
+
+</project>

--- a/backend/jvstm-inmem/runtime/pom.xml
+++ b/backend/jvstm-inmem/runtime/pom.xml
@@ -1,0 +1,58 @@
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>pt.ist</groupId>
+        <artifactId>fenix-framework-backend-jvstm-inmem</artifactId>
+        <!-- Perhaps in Maven 3.1 the version may be ommitted -->
+        <version>2.7.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>fenix-framework-backend-jvstm-inmem-runtime</artifactId>
+    <name>Fenix Framework InMemory JVSTM Backend Runtime</name>
+    <description>InMemory backend</description>
+
+    <build>
+        <plugins>
+            <!-- Process dml file class immediately before compiling -->
+            <plugin>
+                <groupId>pt.ist</groupId>
+                <artifactId>ff-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>ff-generate-domain</goal>
+                            <goal>ff-process-atomic-annotations</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- setup jar maker not to include generated classes -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${version.maven.jar-plugin}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*_Base*</exclude>
+                        <exclude>pt/ist/fenixframework/ValueTypeSerializer*</exclude>
+                        <exclude>pt/ist/fenixframework/backend/CurrentBackEndId*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>pt.ist</groupId>
+            <artifactId>fenix-framework-backend-jvstm-common-runtime</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/backend/jvstm-inmem/runtime/src/main/java/pt/ist/fenixframework/backend/jvstm/InMemDomainObject.java
+++ b/backend/jvstm-inmem/runtime/src/main/java/pt/ist/fenixframework/backend/jvstm/InMemDomainObject.java
@@ -1,0 +1,29 @@
+package pt.ist.fenixframework.backend.jvstm;
+
+import pt.ist.fenixframework.FenixFramework;
+import pt.ist.fenixframework.core.SharedIdentityMap;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Created by diutsu on 30/11/16.
+ */
+public class InMemDomainObject extends JVSTMDomainObject {
+    
+    
+    @Override
+    protected void deleteDomainObject() {
+        this.invokeDeletionListeners();
+        try {
+            Field cacheField = SharedIdentityMap.class.getDeclaredField("cache");
+            cacheField.setAccessible(true);
+            ConcurrentHashMap<Object, ?> cache = (ConcurrentHashMap<Object, ?>) cacheField.get(SharedIdentityMap.getCache());
+            cache.remove(this.getOid());
+            ((InMemDomainObjectValidBackEnd) FenixFramework.getConfig().getBackEnd())
+                .deleteObject(this.getOid());
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/backend/jvstm-inmem/runtime/src/main/java/pt/ist/fenixframework/backend/jvstm/InMemDomainObjectValidBackEnd.java
+++ b/backend/jvstm-inmem/runtime/src/main/java/pt/ist/fenixframework/backend/jvstm/InMemDomainObjectValidBackEnd.java
@@ -1,0 +1,49 @@
+package pt.ist.fenixframework.backend.jvstm;
+
+import pt.ist.fenixframework.DomainObject;
+import pt.ist.fenixframework.FenixFramework;
+import pt.ist.fenixframework.backend.jvstm.repository.NoRepository;
+
+import java.util.HashSet;
+
+/***
+ * 
+ * This backend is necessary since {@link JVSTMBackEnd} throws {@link UnsupportedOperationException} when invoking
+ * {@link FenixFramework#isDomainObjectValid(DomainObject)}
+ * 
+ * @author Sérgio Silva (sergio.silva@tecnico.ulisboa.pt)
+ * @see JVSTMBackEnd#isDomainObjectValid(DomainObject)
+ * 
+ */
+public class InMemDomainObjectValidBackEnd extends JVSTMBackEnd {
+    
+    public static final String BACKEND_NAME = "inmem-backend";
+    
+    
+    protected final HashSet<Object> deletedObjects;
+    
+    public InMemDomainObjectValidBackEnd() {
+        super(new NoRepository());
+        deletedObjects = new HashSet<>();
+    }
+    
+    @Override
+    public <T extends DomainObject> T fromOid(Object oid) {
+        if (deletedObjects.contains(oid))
+            return null;
+        else
+            return super.fromOid(oid);
+    }
+    
+    protected void deleteObject(Object oid){
+        deletedObjects.add(oid);
+    }
+    
+    @Override
+    public boolean isDomainObjectValid(DomainObject object) {
+        return object != null && !deletedObjects.contains(object.getExternalId());
+    }
+
+    
+    
+}

--- a/backend/jvstm-inmem/runtime/src/main/java/pt/ist/fenixframework/backend/jvstm/InMemDomainObjectValidConfig.java
+++ b/backend/jvstm-inmem/runtime/src/main/java/pt/ist/fenixframework/backend/jvstm/InMemDomainObjectValidConfig.java
@@ -1,0 +1,20 @@
+package pt.ist.fenixframework.backend.jvstm;
+
+import pt.ist.fenixframework.FenixFramework;
+import pt.ist.fenixframework.backend.jvstm.JVSTMConfig;
+
+/***
+ * 
+ * Used to initialize {@link FenixFramework} with {@link InMemDomainObjectValidBackEnd}
+ * 
+ * Used in fenix-framework.properties for testing.
+ * 
+ * @author Sérgio Silva (sergio.silva@tecnico.ulisboa.pt)
+ *
+ */
+public class InMemDomainObjectValidConfig extends JVSTMConfig {
+
+    public InMemDomainObjectValidConfig() {
+        this.backEnd = new InMemDomainObjectValidBackEnd();
+    }
+}

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -21,6 +21,7 @@
         <module>jvstm-datagrid</module>
         <module>jvstm-infinispan</module>
         <module>jvstm-lf</module>
+        <module>jvstm-inmem</module>
         <module>jvstm-mem</module>
         <module>jvstm-ojb</module>
         <module>mem</module>

--- a/core/dml-compiler/code-generator/src/main/java/pt/ist/fenixframework/DmlCompiler.java
+++ b/core/dml-compiler/code-generator/src/main/java/pt/ist/fenixframework/DmlCompiler.java
@@ -49,7 +49,7 @@ public class DmlCompiler {
         }
     }
 
-    public static DomainModel getDomainModel(CompilerArgs compArgs) throws DmlCompilerException {
+    public static DomainModel   getDomainModel(CompilerArgs compArgs) throws DmlCompilerException {
         // IMPORTANT: external specs must be first.  The order is important for the DmlCompiler
         List<URL> dmlSpecs = new ArrayList<URL>(compArgs.getExternalDomainSpecs());
         dmlSpecs.addAll(compArgs.getLocalDomainSpecs());

--- a/core/dml-compiler/dml/src/main/java/pt/ist/fenixframework/core/DmlFile.java
+++ b/core/dml-compiler/dml/src/main/java/pt/ist/fenixframework/core/DmlFile.java
@@ -1,6 +1,7 @@
 package pt.ist.fenixframework.core;
 
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/core/dml-compiler/dml/src/main/java/pt/ist/fenixframework/core/Project.java
+++ b/core/dml-compiler/dml/src/main/java/pt/ist/fenixframework/core/Project.java
@@ -39,6 +39,7 @@ public class Project {
     private final List<Project> dependencies;
     private final List<Project> optionalDependencies;
     private final List<Project> depended = new ArrayList<Project>();
+    private ArrayList<DmlFile> sourceDmls = new ArrayList<>();;
 
     /**
      * @deprecated Use constructor with version
@@ -104,6 +105,7 @@ public class Project {
         for (Project dependencyProject : getProjects()) {
             dmlFiles.addAll(dependencyProject.getDmls());
         }
+        dmlFiles.addAll(sourceDmls);
         return dmlFiles;
     }
 
@@ -173,7 +175,10 @@ public class Project {
         Properties properties = new Properties();
         properties.setProperty(NAME_KEY, getName());
         properties.setProperty(VERSION_KEY, getVersion());
-        properties.setProperty(DML_FILES_KEY, join(getDmls(), Collections.emptyList()));
+        ArrayList<DmlFile> dmls = new ArrayList<>();
+        dmls.addAll(getDmls());
+        dmls.addAll(sourceDmls);
+        properties.setProperty(DML_FILES_KEY, join(dmls, Collections.emptyList()));
         if (dependencies.size() > 0) {
             properties.setProperty(DEPENDS_KEY, join(getDependencyProjects(), getOptionalDependencies()));
         }
@@ -234,5 +239,9 @@ public class Project {
             new Project(name, version, dependencyDmlFiles, dependencies, false);
         }
         return projects.get(name);
+    }
+
+    public void setSourceDmls(ArrayList<DmlFile> sourceDmls) {
+        this.sourceDmls = sourceDmls;
     }
 }

--- a/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/DmlZipCreatorMojo.java
+++ b/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/DmlZipCreatorMojo.java
@@ -123,8 +123,7 @@ public class DmlZipCreatorMojo extends AbstractMojo {
 
         try {
             Project project =
-                    DmlMojoUtils.getProject(mavenProject, dmlSourceDirectory, zipDestinationDirectory, dmlFiles, getLog(),
-                            verbose);
+                    DmlMojoUtils.getProject(mavenProject, dmlSourceDirectory, zipDestinationDirectory, dmlFiles, getLog(),verbose);
 
             List<URL> dmls = new ArrayList<URL>();
             for (DmlFile dmlFile : project.getFullDmlSortedList()) {

--- a/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/TestDmlCodeGeneratorMojo.java
+++ b/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/TestDmlCodeGeneratorMojo.java
@@ -5,6 +5,9 @@
 package pt.ist.fenixframework.dml.maven;
 
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -118,6 +121,11 @@ public class TestDmlCodeGeneratorMojo extends AbstractDmlCodeGeneratorMojo {
             super.execute();
             getMavenProject().addTestCompileSourceRoot(getGeneratedSourcesDirectory().getAbsolutePath());
         }
+    }
+
+    @Override
+    protected File getMainDmlDirectory() throws MalformedURLException {
+        return new File(mavenProject.getBasedir() + "/src/main/dml");
     }
 
     @Override


### PR DESCRIPTION
Currently when running tests only the dml files on /src/test/dml are read, this leads to a creation of a second module to only hold the tests.
This is not standard, the tests are not run automatically by CI tools, leading to not running the tests at all.

First add /src/main/dml files when using TestDmlCodeGeneratorMojo.java to the code generator process.
Secondly add the same dml files to the generated project.properties files on the /target directory to be recognized by the Framework during initialization