### PR TITLE
Updated dependencies to support java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
 
 jdk:
-    - oraclejdk7
+    - openjdk8
+    - openjdk11

--- a/backend/infinispan/code-generator/pom.xml
+++ b/backend/infinispan/code-generator/pom.xml
@@ -137,20 +137,6 @@
                 <updatePolicy>never</updatePolicy>
             </snapshots>
         </repository>
-        <repository>
-            <id>pruivo-public-repository-group</id>
-            <name>Pedro Ruivo Public Maven Repository Group</name>
-            <url>http://homepages.gsd.inesc-id.pt/~pruivo/maven-repo/</url>
-            <layout>default</layout>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-            </snapshots>
-        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -166,21 +152,6 @@
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
-            </snapshots>
-        </pluginRepository>
-
-        <pluginRepository>
-            <id>pruivo-public-repository-group</id>
-            <name>Pedro Ruivo Public Maven Repository Group</name>
-            <url>http://homepages.gsd.inesc-id.pt/~pruivo/maven-repo/</url>
-            <layout>default</layout>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
             </snapshots>
         </pluginRepository>
     </pluginRepositories>

--- a/backend/infinispan/runtime/pom.xml
+++ b/backend/infinispan/runtime/pom.xml
@@ -141,20 +141,6 @@
                 <updatePolicy>never</updatePolicy>
             </snapshots>
         </repository>
-        <repository>
-            <id>pruivo-public-repository-group</id>
-            <name>Pedro Ruivo Public Maven Repository Group</name>
-            <url>http://homepages.gsd.inesc-id.pt/~pruivo/maven-repo/</url>
-            <layout>default</layout>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-            </snapshots>
-        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -170,21 +156,6 @@
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
-            </snapshots>
-        </pluginRepository>
-
-        <pluginRepository>
-            <id>pruivo-public-repository-group</id>
-            <name>Pedro Ruivo Public Maven Repository Group</name>
-            <url>http://homepages.gsd.inesc-id.pt/~pruivo/maven-repo/</url>
-            <layout>default</layout>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
             </snapshots>
         </pluginRepository>
     </pluginRepositories>

--- a/backend/jvstm-ojb/runtime/src/main/java/pt/ist/fenixframework/backend/jvstmojb/JvstmOJBBackEnd.java
+++ b/backend/jvstm-ojb/runtime/src/main/java/pt/ist/fenixframework/backend/jvstmojb/JvstmOJBBackEnd.java
@@ -79,11 +79,7 @@ public class JvstmOJBBackEnd implements BackEnd {
 
     @Override
     public void shutdown() {
-        try {
-            AbandonedConnectionCleanupThread.shutdown();
-        } catch (InterruptedException e) {
-            logger.info("Error while shutting down AbandonedConnectionCleanupThread", e);
-        }
+        AbandonedConnectionCleanupThread.shutdown();
         DbUtil.deregisterDriver();
     }
 

--- a/core/api/pom.xml
+++ b/core/api/pom.xml
@@ -44,7 +44,7 @@
                     </dependency>
                     <dependency>
                         <groupId>org.ow2.asm</groupId>
-                        <artifactId>asm-debug-all</artifactId>
+                        <artifactId>asm</artifactId>
                         <version>${version.asm}</version>
                     </dependency>
                 </dependencies>
@@ -113,6 +113,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
         </dependency>
     </dependencies>
 

--- a/core/dml-compiler/code-generator/src/main/java/pt/ist/fenixframework/core/PostProcessDomainClasses.java
+++ b/core/dml-compiler/code-generator/src/main/java/pt/ist/fenixframework/core/PostProcessDomainClasses.java
@@ -67,7 +67,7 @@ public class PostProcessDomainClasses extends AbstractDomainPostProcessor {
         private boolean warnOnFiels = false;
 
         public AddOJBConstructorClassAdapter(ClassVisitor cv) {
-            super(Opcodes.ASM4, cv);
+            super(Opcodes.ASM7, cv);
         }
 
         @Override

--- a/maven/archetypes/application-archetype-clean/src/main/resources/archetype-resources/pom.xml
+++ b/maven/archetypes/application-archetype-clean/src/main/resources/archetype-resources/pom.xml
@@ -92,15 +92,15 @@
 
     <repositories>
         <repository>
-            <id>fenix-ashes-maven-repository</id>
-            <url>https://fenix-ashes.ist.utl.pt/nexus/content/groups/fenix-ashes-maven-repository</url>
+            <id>fenixedu-maven-repository</id>
+            <url>https://repo.fenixedu.org/fenixedu-maven-repository</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
-            <id>fenix-ashes-maven-repository</id>
-            <url>https://fenix-ashes.ist.utl.pt/nexus/content/groups/fenix-ashes-maven-repository</url>
+            <id>fenixedu-maven-repository</id>
+            <url>https://repo.fenixedu.org/fenixedu-maven-repository</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/maven/archetypes/module-archetype-clean/src/main/resources/archetype-resources/pom.xml
+++ b/maven/archetypes/module-archetype-clean/src/main/resources/archetype-resources/pom.xml
@@ -101,15 +101,15 @@
 
     <repositories>
         <repository>
-            <id>fenix-ashes-maven-repository</id>
-            <url>https://fenix-ashes.ist.utl.pt/nexus/content/groups/fenix-ashes-maven-repository</url>
+            <id>fenixedu-maven-repository</id>
+            <url>https://repo.fenixedu.org/fenixedu-maven-repository</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
-            <id>fenix-ashes-maven-repository</id>
-            <url>https://fenix-ashes.ist.utl.pt/nexus/content/groups/fenix-ashes-maven-repository</url>
+            <id>fenixedu-maven-repository</id>
+            <url>https://repo.fenixedu.org/fenixedu-maven-repository</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/maven/archetypes/webapp-archetype-clean/src/main/resources/archetype-resources/pom.xml
+++ b/maven/archetypes/webapp-archetype-clean/src/main/resources/archetype-resources/pom.xml
@@ -106,15 +106,15 @@
 
     <repositories>
         <repository>
-            <id>fenix-ashes-maven-repository</id>
-            <url>https://fenix-ashes.ist.utl.pt/nexus/content/groups/fenix-ashes-maven-repository</url>
+            <id>fenixedu-maven-repository</id>
+            <url>https://repo.fenixedu.org/fenixedu-maven-repository</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
-            <id>fenix-ashes-maven-repository</id>
-            <url>https://fenix-ashes.ist.utl.pt/nexus/content/groups/fenix-ashes-maven-repository</url>
+            <id>fenixedu-maven-repository</id>
+            <url>https://repo.fenixedu.org/fenixedu-maven-repository</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/maven/atomic-maven-plugin/pom.xml
+++ b/maven/atomic-maven-plugin/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-debug-all</artifactId>
+            <artifactId>asm</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/maven/atomic-maven-plugin/src/main/java/pt/ist/fenixframework/atomic/maven/TestAtomicPostProcessorMojo.java
+++ b/maven/atomic-maven-plugin/src/main/java/pt/ist/fenixframework/atomic/maven/TestAtomicPostProcessorMojo.java
@@ -25,7 +25,7 @@ public class TestAtomicPostProcessorMojo extends AbstractAtomicProcessorMojo {
     /**
      * Setting this to 'true' skips this post-processing
      * 
-     * @parameter expression="${maven.test.skip}"
+     * @parameter property="maven.test.skip"
      */
     protected boolean skip;
 

--- a/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/DmlCodeGeneratorMojo.java
+++ b/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/DmlCodeGeneratorMojo.java
@@ -56,7 +56,7 @@ public class DmlCodeGeneratorMojo extends AbstractDmlCodeGeneratorMojo {
     /**
      * Code Generator Class Name
      * 
-     * @parameter expression="${generate-domain.codeGeneratorClassName}"
+     * @parameter property="generate-domain.codeGeneratorClassName"
      *            default-value="pt.ist.fenixframework.dml.DefaultCodeGenerator"
      */
     protected String codeGeneratorClassName;
@@ -64,28 +64,28 @@ public class DmlCodeGeneratorMojo extends AbstractDmlCodeGeneratorMojo {
     /**
      * Package name
      * 
-     * @parameter expression="${generate-domain.packageName}"
+     * @parameter property="generate-domain.packageName"
      */
     protected String packageName = "";
 
     /**
      * Generate Finals Flag
      * 
-     * @parameter expression="${generate-domain.generateFinals}" default-value="false"
+     * @parameter property="generate-domain.generateFinals" default-value="false"
      */
     protected boolean generateFinals;
 
     /**
      * Verbose Mode Flag
      * 
-     * @parameter expression="${verbose}" default-value="false"
+     * @parameter property="verbose" default-value="false"
      */
     protected boolean verbose;
 
     /**
      * Generate Project Properties Flag
      * 
-     * @parameter expression="${generate-domain.generateProjectProperties}" default-value="false"
+     * @parameter property="generate-domain.generateProjectProperties" default-value="false"
      */
     protected boolean generateProjectProperties;
 

--- a/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/DmlPostProcessorMojo.java
+++ b/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/DmlPostProcessorMojo.java
@@ -47,7 +47,7 @@ public class DmlPostProcessorMojo extends AbstractDmlPostProcessorMojo {
     /**
      * Code Generator Class Name
      * 
-     * @parameter expression="${generate-domain.codeGeneratorClassName}"
+     * @parameter property="generate-domain.codeGeneratorClassName"
      *            default-value="pt.ist.fenixframework.dml.DefaultCodeGenerator"
      */
     protected String codeGeneratorClassName;
@@ -55,7 +55,7 @@ public class DmlPostProcessorMojo extends AbstractDmlPostProcessorMojo {
     /**
      * Verbose Mode Flag
      * 
-     * @parameter expression="${generate-domain.verbose}"
+     * @parameter property="generate-domain.verbose"
      *            default-value="false"
      */
     protected boolean verbose;

--- a/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/DmlZipCreatorMojo.java
+++ b/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/DmlZipCreatorMojo.java
@@ -61,7 +61,7 @@ public class DmlZipCreatorMojo extends AbstractMojo {
     /**
      * Verbose Mode Flag
      * 
-     * @parameter expression="${verbose}" default-value="false"
+     * @parameter property="verbose" default-value="false"
      */
     protected boolean verbose;
 

--- a/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/TestDmlCodeGeneratorMojo.java
+++ b/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/TestDmlCodeGeneratorMojo.java
@@ -36,7 +36,7 @@ public class TestDmlCodeGeneratorMojo extends AbstractDmlCodeGeneratorMojo {
     /**
      * Set this to 'true' to bypass compilation of dml test sources.
      * 
-     * @parameter expression="${maven.test.skip}"
+     * @parameter property="maven.test.skip"
      */
     protected boolean skip;
 
@@ -70,7 +70,7 @@ public class TestDmlCodeGeneratorMojo extends AbstractDmlCodeGeneratorMojo {
     /**
      * Code Generator Class Name
      * 
-     * @parameter expression="${generate-domain.codeGeneratorClassName}"
+     * @parameter property="generate-domain.codeGeneratorClassName"
      *            default-value="pt.ist.fenixframework.dml.DefaultCodeGenerator"
      */
     protected String codeGeneratorClassName;
@@ -78,14 +78,14 @@ public class TestDmlCodeGeneratorMojo extends AbstractDmlCodeGeneratorMojo {
     /**
      * Package name
      * 
-     * @parameter expression="${test-generate-domain.packageName}"
+     * @parameter property="test-generate-domain.packageName"
      */
     protected String packageName = "";
 
     /**
      * Generate Finals Flag
      * 
-     * @parameter expression="${test-generate-domain.generateFinals}"
+     * @parameter property="test-generate-domain.generateFinals"
      *            default-value="false"
      */
     protected boolean generateFinals;
@@ -93,7 +93,7 @@ public class TestDmlCodeGeneratorMojo extends AbstractDmlCodeGeneratorMojo {
     /**
      * Verbose Mode Flag
      * 
-     * @parameter expression="${verbose}"
+     * @parameter property="verbose"
      *            default-value="false"
      */
     protected boolean verbose;
@@ -101,7 +101,7 @@ public class TestDmlCodeGeneratorMojo extends AbstractDmlCodeGeneratorMojo {
     /**
      * Generate Project Properties Flag
      * 
-     * @parameter expression="${test-generate-domain.generateProjectProperties}"
+     * @parameter property="test-generate-domain.generateProjectProperties"
      *            default-value="false"
      */
     protected boolean generateProjectProperties;

--- a/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/TestDmlPostProcessorMojo.java
+++ b/maven/dml-maven-plugin/src/main/java/pt/ist/fenixframework/dml/maven/TestDmlPostProcessorMojo.java
@@ -29,7 +29,7 @@ public class TestDmlPostProcessorMojo extends AbstractDmlPostProcessorMojo {
     /**
      * Setting this to 'true' skips post-processing of dml compiled test classes.
      * 
-     * @parameter expression="${maven.test.skip}"
+     * @parameter property="maven.test.skip"
      */
     protected boolean skip;
 
@@ -54,7 +54,7 @@ public class TestDmlPostProcessorMojo extends AbstractDmlPostProcessorMojo {
     /**
      * Code Generator Class Name
      * 
-     * @parameter expression="${generate-domain.codeGeneratorClassName}"
+     * @parameter property="generate-domain.codeGeneratorClassName"
      *            default-value="pt.ist.fenixframework.dml.DefaultCodeGenerator"
      */
     protected String codeGeneratorClassName;
@@ -62,7 +62,7 @@ public class TestDmlPostProcessorMojo extends AbstractDmlPostProcessorMojo {
     /**
      * Verbose Mode Flag
      * 
-     * @parameter expression="${generate-domain.verbose}"
+     * @parameter property="generate-domain.verbose"
      *            default-value="false"
      */
     protected boolean verbose;

--- a/maven/ff-maven-plugin/src/main/java/pt/ist/fenixframework/maven/FFDmlCodeGeneratorMojo.java
+++ b/maven/ff-maven-plugin/src/main/java/pt/ist/fenixframework/maven/FFDmlCodeGeneratorMojo.java
@@ -56,7 +56,7 @@ public class FFDmlCodeGeneratorMojo extends DmlCodeGeneratorMojo {
     /**
      * Code Generator Class Name
      * 
-     * @parameter expression="${generate-domain.codeGeneratorClassName}"
+     * @parameter property="generate-domain.codeGeneratorClassName"
      *            default-value="pt.ist.fenixframework.dml.DefaultCodeGenerator"
      */
     protected String codeGeneratorClassName;
@@ -64,28 +64,28 @@ public class FFDmlCodeGeneratorMojo extends DmlCodeGeneratorMojo {
     /**
      * Package name
      * 
-     * @parameter expression="${generate-domain.packageName}"
+     * @parameter property="generate-domain.packageName"
      */
     protected final String packageName = "";
 
     /**
      * Generate Finals Flag
      * 
-     * @parameter expression="${generate-domain.generateFinals}" default-value="false"
+     * @parameter property="generate-domain.generateFinals" default-value="false"
      */
     protected boolean generateFinals;
 
     /**
      * Verbose Mode Flag
      * 
-     * @parameter expression="${verbose}" default-value="false"
+     * @parameter property="verbose" default-value="false"
      */
     protected boolean verbose;
 
     /**
      * Generate Project Properties Flag
      * 
-     * @parameter expression="${generate-domain.generateProjectProperties}" default-value="false"
+     * @parameter property="generate-domain.generateProjectProperties" default-value="false"
      */
     protected boolean generateProjectProperties;
 

--- a/maven/ff-maven-plugin/src/main/java/pt/ist/fenixframework/maven/FFDmlPostProcessorMojo.java
+++ b/maven/ff-maven-plugin/src/main/java/pt/ist/fenixframework/maven/FFDmlPostProcessorMojo.java
@@ -46,7 +46,7 @@ public class FFDmlPostProcessorMojo extends DmlPostProcessorMojo {
     /**
      * Code Generator Class Name
      * 
-     * @parameter expression="${generate-domain.codeGeneratorClassName}"
+     * @parameter property="generate-domain.codeGeneratorClassName"
      *            default-value="pt.ist.fenixframework.dml.DefaultCodeGenerator"
      */
     protected String codeGeneratorClassName;
@@ -54,7 +54,7 @@ public class FFDmlPostProcessorMojo extends DmlPostProcessorMojo {
     /**
      * Verbose Mode Flag
      * 
-     * @parameter expression="${generate-domain.verbose}"
+     * @parameter property="generate-domain.verbose"
      *            default-value="false"
      */
     protected boolean verbose;

--- a/maven/ff-maven-plugin/src/main/java/pt/ist/fenixframework/maven/FFDmlZipCreatorMojo.java
+++ b/maven/ff-maven-plugin/src/main/java/pt/ist/fenixframework/maven/FFDmlZipCreatorMojo.java
@@ -44,7 +44,7 @@ public class FFDmlZipCreatorMojo extends DmlZipCreatorMojo {
     /**
      * Verbose Mode Flag
      * 
-     * @parameter expression="${verbose}" default-value="false"
+     * @parameter property="verbose" default-value="false"
      */
     private boolean verbose;
 

--- a/maven/ff-maven-plugin/src/main/java/pt/ist/fenixframework/maven/FFTestAtomicPostProcessorMojo.java
+++ b/maven/ff-maven-plugin/src/main/java/pt/ist/fenixframework/maven/FFTestAtomicPostProcessorMojo.java
@@ -27,7 +27,7 @@ public class FFTestAtomicPostProcessorMojo extends TestAtomicPostProcessorMojo {
     /**
      * Setting this to 'true' skips this post-processing
      * 
-     * @parameter expression="${maven.test.skip}"
+     * @parameter property="maven.test.skip"
      */
     protected boolean skip;
 

--- a/maven/ff-maven-plugin/src/main/java/pt/ist/fenixframework/maven/FFTestDmlCodeGeneratorMojo.java
+++ b/maven/ff-maven-plugin/src/main/java/pt/ist/fenixframework/maven/FFTestDmlCodeGeneratorMojo.java
@@ -29,7 +29,7 @@ public class FFTestDmlCodeGeneratorMojo extends TestDmlCodeGeneratorMojo {
     /**
      * Set this to 'true' to bypass compilation of dml test sources.
      * 
-     * @parameter expression="${maven.test.skip}"
+     * @parameter property="maven.test.skip"
      */
     protected boolean skip;
 
@@ -63,7 +63,7 @@ public class FFTestDmlCodeGeneratorMojo extends TestDmlCodeGeneratorMojo {
     /**
      * Code Generator Class Name
      * 
-     * @parameter expression="${generate-domain.codeGeneratorClassName}"
+     * @parameter property="generate-domain.codeGeneratorClassName"
      *            default-value="pt.ist.fenixframework.dml.DefaultCodeGenerator"
      */
     protected String codeGeneratorClassName;
@@ -71,14 +71,14 @@ public class FFTestDmlCodeGeneratorMojo extends TestDmlCodeGeneratorMojo {
     /**
      * Package name
      * 
-     * @parameter expression="${test-generate-domain.packageName}"
+     * @parameter property="test-generate-domain.packageName"
      */
     protected final String packageName = "";
 
     /**
      * Generate Finals Flag
      * 
-     * @parameter expression="${test-generate-domain.generateFinals}"
+     * @parameter property="test-generate-domain.generateFinals"
      *            default-value="false"
      */
     protected boolean generateFinals;
@@ -86,7 +86,7 @@ public class FFTestDmlCodeGeneratorMojo extends TestDmlCodeGeneratorMojo {
     /**
      * Verbose Mode Flag
      * 
-     * @parameter expression="${verbose}"
+     * @parameter property="verbose"
      *            default-value="false"
      */
     protected boolean verbose;
@@ -94,7 +94,7 @@ public class FFTestDmlCodeGeneratorMojo extends TestDmlCodeGeneratorMojo {
     /**
      * Generate Project Properties Flag
      * 
-     * @parameter expression="${test-generate-domain.generateProjectProperties}"
+     * @parameter property="test-generate-domain.generateProjectProperties"
      *            default-value="false"
      */
     protected boolean generateProjectProperties;

--- a/maven/ff-maven-plugin/src/main/java/pt/ist/fenixframework/maven/FFTestDmlPostProcessorMojo.java
+++ b/maven/ff-maven-plugin/src/main/java/pt/ist/fenixframework/maven/FFTestDmlPostProcessorMojo.java
@@ -28,7 +28,7 @@ public class FFTestDmlPostProcessorMojo extends TestDmlPostProcessorMojo {
     /**
      * Setting this to 'true' skips post-processing of dml compiled test classes.
      * 
-     * @parameter expression="${maven.test.skip}"
+     * @parameter property="maven.test.skip"
      */
     protected boolean skip;
 
@@ -53,7 +53,7 @@ public class FFTestDmlPostProcessorMojo extends TestDmlPostProcessorMojo {
     /**
      * Code Generator Class Name
      * 
-     * @parameter expression="${generate-domain.codeGeneratorClassName}"
+     * @parameter property="generate-domain.codeGeneratorClassName"
      *            default-value="pt.ist.fenixframework.dml.DefaultCodeGenerator"
      */
     protected String codeGeneratorClassName;
@@ -61,7 +61,7 @@ public class FFTestDmlPostProcessorMojo extends TestDmlPostProcessorMojo {
     /**
      * Verbose Mode Flag
      * 
-     * @parameter expression="${generate-domain.verbose}"
+     * @parameter property="generate-domain.verbose"
      *            default-value="false"
      */
     protected boolean verbose;

--- a/pom.xml
+++ b/pom.xml
@@ -26,45 +26,45 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- PLEASE KEEP THIS LIST SORTED ALPHABETICALLY!!! THANKS -->
-        <version.advice>1.8</version.advice>
+        <version.advice>1.9</version.advice>
         <version.antlr>2.7.7</version.antlr>
-        <version.apache.ant>1.8.2</version.apache.ant>
-        <version.asm>5.0</version.asm>
-        <version.commons.codec>1.7</version.commons.codec>
-        <version.commons.io>2.4</version.commons.io>
+        <version.apache.ant>1.10.7</version.apache.ant>
+        <version.asm>7.2</version.asm>
+        <version.commons.codec>1.13</version.commons.codec>
+        <version.commons.io>2.6</version.commons.io>
         <version.commons.lang>2.6</version.commons.lang>
-        <version.com.google.code.gson>2.2.4</version.com.google.code.gson>
+        <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
         <version.dap-framework>2.0</version.dap-framework>
-        <version.hazelcast.api>3.0-RC1</version.hazelcast.api>
+        <version.hazelcast.api>3.12.4</version.hazelcast.api>
         <version.hibernate.ogm.core>${version.hibernate.ogm}</version.hibernate.ogm.core>
         <version.hibernate.ogm.infinispan>${version.hibernate.ogm}</version.hibernate.ogm.infinispan>
         <version.hibernate.ogm>4.0.0.Beta1</version.hibernate.ogm>
         <version.hibernate.search>4.2.0.Beta2</version.hibernate.search>
         <version.hibernate>4.0.1.Final</version.hibernate>
         <version.infinispan>5.2.1.Final</version.infinispan>
-        <version.jboss.logging>3.1.0.GA</version.jboss.logging>
-        <version.jbossjta>4.16.3.Final</version.jbossjta>
-        <version.jgroups>3.2.7.Final</version.jgroups>
-        <version.jodatime>1.6.2</version.jodatime>
-        <version.jpa>1.0</version.jpa>
+        <version.jboss.logging>3.4.1.Final</version.jboss.logging>
+        <version.jbossjta>4.16.6.Final</version.jbossjta>
+        <version.jgroups>3.6.19.Final</version.jgroups>
+        <version.jodatime>2.10.5</version.jodatime>
+        <version.jpa>1.0.2</version.jpa>
         <version.jta>1.1</version.jta>
-        <version.junit>4.10</version.junit>
+        <version.junit>4.12</version.junit>
         <version.jvstm-fenix>1.4</version.jvstm-fenix>
-        <version.jvstm-lock-free>2.1</version.jvstm-lock-free>
+        <version.jvstm-lock-free>2.3</version.jvstm-lock-free>
         <version.maven.antlr-plugin>2.2</version.maven.antlr-plugin>
         <version.maven.build-helper-plugin>1.7</version.maven.build-helper-plugin>
-        <version.maven.core>3.0.3</version.maven.core>
-        <version.maven.exec-plugin>1.2.1</version.maven.exec-plugin>
-        <version.maven.jar-plugin>2.4</version.maven.jar-plugin>
-        <version.maven.javadoc-plugin>2.8.1</version.maven.javadoc-plugin>
+        <version.maven.core>3.6.3</version.maven.core>
+        <version.maven.exec-plugin>1.6.0</version.maven.exec-plugin>
+        <version.maven.jar-plugin>3.2.0</version.maven.jar-plugin>
+        <version.maven.javadoc-plugin>3.1.1</version.maven.javadoc-plugin>
         <version.maven.plexus-plugin>1.3.8</version.maven.plexus-plugin>
-        <version.maven.release.plugin>2.5</version.maven.release.plugin>
+        <version.maven.release.plugin>2.5.3</version.maven.release.plugin>
         <version.maven.replacer-plugin>1.5.2</version.maven.replacer-plugin>
         <version.maven.umlgraph-doclet-plugin>5.1</version.maven.umlgraph-doclet-plugin>
-        <version.mysql.connector>5.1.34</version.mysql.connector>
+        <version.mysql.connector>5.1.47</version.mysql.connector>
         <version.ojb>1.0.0-escaped</version.ojb>
         <version.rhq.helpers>3.0.4</version.rhq.helpers>
-        <version.slf4j.api>1.7.2</version.slf4j.api>
+        <version.slf4j.api>1.7.29</version.slf4j.api>
 
         <!-- Used in surefire plugin -->
         <!-- to play on the safe side when do not run tests in parallel. To do so run maven, e.g. with -DforkCount=1.5C -->
@@ -78,17 +78,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <proc>none</proc>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.2</version>
+                <version>1.4.1</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -108,7 +108,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.14</version>
+                <version>2.22.0</version>
                 <configuration>
                     <reuseForks>false</reuseForks>
                     <forkCount>${forkCount}</forkCount>
@@ -161,6 +161,11 @@
                         </manifest>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.6.0</version>
             </plugin>
         </plugins>
     </build>
@@ -288,7 +293,7 @@
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-debug-all</artifactId>
+                <artifactId>asm</artifactId>
                 <version>${version.asm}</version>
             </dependency>
             <dependency>
@@ -337,14 +342,19 @@
                 <artifactId>gson</artifactId>
                 <version>${version.com.google.code.gson}</version>
             </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <!-- Repositories -->
     <repositories>
         <repository>
-            <id>fenix-ashes-maven-repository</id>
-            <url>https://fenix-ashes.ist.utl.pt/nexus/content/groups/fenix-ashes-maven-repository</url>
+            <id>fenixedu-maven-repository</id>
+            <url>https://repo.fenixedu.org/fenixedu-maven-repository</url>
         </repository>
 
         <repository>
@@ -411,8 +421,8 @@
 
     <pluginRepositories>
         <pluginRepository>
-            <id>fenix-ashes-maven-repository</id>
-            <url>https://fenix-ashes.ist.utl.pt/nexus/content/groups/fenix-ashes-maven-repository</url>
+            <id>fenixedu-maven-repository</id>
+            <url>https://repo.fenixedu.org/fenixedu-maven-repository</url>
         </pluginRepository>
 
         <pluginRepository>


### PR DESCRIPTION
<s>This is a draft PR and is blocked by the Java 11 updates on the advice project (https://github.com/fenix-framework/advice/pull/1)


- if this gets merged, the advice version should be fixed in the pom.xml (currently 1.9-SNAPSHOT)
- also did minor automatic code cleanups: e.g. javadoc property, redundant explicit typing
</s>